### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:8-alpine
+
+LABEL maintainer="etienne@tomochain.com"
+
+ENV WS_SECRET ''
+
+WORKDIR /ethnetstats
+
+COPY ./ ./
+
+RUN npm install && \
+    npm install -g grunt-cli && \
+    grunt
+
+ENTRYPOINT ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@ Tomochain Network Stats
 ============
 
 Fork of [cubedro/eth-netstats](https://github.com/cubedro/eth-netstats) used to expose Tomochain network status.
+
+## Usage
+```
+docker run -e "WS_SECRET=$SECRET" -p "3000:3000" tomochain/eth-netstats
+```


### PR DESCRIPTION
Add Dockerfile for the base eth-netstats image.
This image is intendeed to be used as a base for the image tomo-netstats which will contain additional infrastructure related related configurations